### PR TITLE
Add topics dataset and Astro page for themed CSS properties

### DIFF
--- a/src/data/topics.js
+++ b/src/data/topics.js
@@ -1,0 +1,3752 @@
+export const topics = [
+  {
+    "theme": "Text & Typography",
+    "items": [
+      {
+        "name": "alignment-baseline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/alignment-baseline",
+        "specUrl": [
+          "https://drafts.csswg.org/css-inline/#alignment-baseline-property",
+          "https://svgwg.org/svg2-draft/text.html#AlignmentBaselineProperty"
+        ],
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "baseline-shift",
+        "mdnUrl": null,
+        "specUrl": [
+          "https://drafts.csswg.org/css-inline/#baseline-shift-property",
+          "https://svgwg.org/svg2-draft/text.html#BaselineShiftProperty"
+        ],
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "baseline-source",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-inline/#baseline-source",
+        "introduced": "2023-03-01"
+      },
+      {
+        "name": "direction",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/direction",
+        "specUrl": [
+          "https://drafts.csswg.org/css-writing-modes/#direction",
+          "https://svgwg.org/svg2-draft/text.html#DirectionProperty"
+        ],
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "dominant-baseline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/dominant-baseline",
+        "specUrl": [
+          "https://drafts.csswg.org/css-inline/#dominant-baseline-property",
+          "https://svgwg.org/svg2-draft/text.html#DominantBaselineProperty"
+        ],
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "font",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-prop",
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "font-family",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-family",
+        "specUrl": [
+          "https://drafts.csswg.org/css-fonts/#generic-font-families",
+          "https://drafts.csswg.org/css-fonts/#font-family-prop"
+        ],
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "font-feature-settings",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-feature-settings",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-feature-settings-prop",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "font-kerning",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-kerning",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-kerning-prop",
+        "introduced": "2014-02-20"
+      },
+      {
+        "name": "font-language-override",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-language-override",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-language-override-prop",
+        "introduced": "2014-12-01"
+      },
+      {
+        "name": "font-optical-sizing",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-optical-sizing",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-optical-sizing-def",
+        "introduced": "2018-04-30"
+      },
+      {
+        "name": "font-palette",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-palette",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-palette-prop",
+        "introduced": "2022-03-14"
+      },
+      {
+        "name": "font-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-size",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-size-prop",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "font-size-adjust",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-size-adjust",
+        "specUrl": "https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "font-stretch",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-stretch",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-stretch-prop",
+        "introduced": "2011-03-14"
+      },
+      {
+        "name": "font-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-style",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-style-prop",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "font-synthesis",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-synthesis",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-synthesis",
+        "introduced": "2014-12-01"
+      },
+      {
+        "name": "font-synthesis-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-synthesis-position",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-synthesis-position",
+        "introduced": "2023-09-26"
+      },
+      {
+        "name": "font-synthesis-small-caps",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-synthesis-small-caps",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-synthesis-small-caps",
+        "introduced": "2022-01-04"
+      },
+      {
+        "name": "font-synthesis-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-synthesis-style",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-synthesis-style",
+        "introduced": "2022-01-04"
+      },
+      {
+        "name": "font-synthesis-weight",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-synthesis-weight",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-synthesis-weight",
+        "introduced": "2022-01-04"
+      },
+      {
+        "name": "font-variant",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variant",
+        "specUrl": [
+          "https://drafts.csswg.org/css-fonts/#font-variant-prop",
+          "https://svgwg.org/svg2-draft/text.html#FontVariantProperty"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "font-variant-alternates",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variant-alternates",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-variant-alternates-prop",
+        "introduced": "2014-12-01"
+      },
+      {
+        "name": "font-variant-caps",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variant-caps",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-variant-caps-prop",
+        "introduced": "2014-12-01"
+      },
+      {
+        "name": "font-variant-east-asian",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variant-east-asian",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-variant-east-asian-prop",
+        "introduced": "2014-12-01"
+      },
+      {
+        "name": "font-variant-emoji",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variant-emoji",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-variant-emoji-prop",
+        "introduced": "2024-05-13"
+      },
+      {
+        "name": "font-variant-ligatures",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variant-ligatures",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-variant-ligatures-prop",
+        "introduced": "2014-04-02"
+      },
+      {
+        "name": "font-variant-numeric",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variant-numeric",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-variant-numeric-prop",
+        "introduced": "2014-12-01"
+      },
+      {
+        "name": "font-variant-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variant-position",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-variant-position-prop",
+        "introduced": "2014-12-01"
+      },
+      {
+        "name": "font-variation-settings",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variation-settings",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-variation-settings-def",
+        "introduced": "2017-09-19"
+      },
+      {
+        "name": "font-weight",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-weight",
+        "specUrl": "https://drafts.csswg.org/css-fonts/#font-weight-prop",
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "font-width",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-fonts/#propdef-font-width",
+        "introduced": "2025-03-31"
+      },
+      {
+        "name": "glyph-orientation-vertical",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-writing-modes-4/#glyph-orientation",
+        "introduced": "2009-06-08"
+      },
+      {
+        "name": "hanging-punctuation",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/hanging-punctuation",
+        "specUrl": "https://drafts.csswg.org/css-text/#hanging-punctuation-property",
+        "introduced": "2016-09-13"
+      },
+      {
+        "name": "hyphenate-character",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/hyphenate-character",
+        "specUrl": "https://drafts.csswg.org/css-text-4/#propdef-hyphenate-character",
+        "introduced": "2022-03-08"
+      },
+      {
+        "name": "hyphenate-limit-chars",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/hyphenate-limit-chars",
+        "specUrl": "https://drafts.csswg.org/css-text-4/#propdef-hyphenate-limit-chars",
+        "introduced": "2023-01-10"
+      },
+      {
+        "name": "hyphens",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/hyphens",
+        "specUrl": "https://drafts.csswg.org/css-text/#hyphens-property",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "initial-letter",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/initial-letter",
+        "specUrl": "https://drafts.csswg.org/css-inline/#sizing-drop-initials",
+        "introduced": "2015-09-16"
+      },
+      {
+        "name": "letter-spacing",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/letter-spacing",
+        "specUrl": [
+          "https://drafts.csswg.org/css-text/#letter-spacing-property",
+          "https://svgwg.org/svg2-draft/text.html#LetterSpacingProperty"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "line-break",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/line-break",
+        "specUrl": "https://drafts.csswg.org/css-text/#line-break-property",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "line-height",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/line-height",
+        "specUrl": "https://drafts.csswg.org/css-inline/#line-height-property",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "overflow-wrap",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overflow-wrap",
+        "specUrl": "https://drafts.csswg.org/css-text/#overflow-wrap-property",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "ruby-align",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/ruby-align",
+        "specUrl": "https://drafts.csswg.org/css-ruby/#ruby-align-property",
+        "introduced": "2015-05-12"
+      },
+      {
+        "name": "ruby-overhang",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/ruby-overhang",
+        "specUrl": "https://drafts.csswg.org/css-ruby/#propdef-ruby-overhang",
+        "introduced": "2024-12-11"
+      },
+      {
+        "name": "ruby-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/ruby-position",
+        "specUrl": "https://drafts.csswg.org/css-ruby/#rubypos",
+        "introduced": "2015-05-12"
+      },
+      {
+        "name": "tab-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/tab-size",
+        "specUrl": "https://drafts.csswg.org/css-text/#tab-size-property",
+        "introduced": "2012-07-31"
+      },
+      {
+        "name": "text-align-last",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-align-last",
+        "specUrl": "https://drafts.csswg.org/css-text/#text-align-last-property",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "text-autospace",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-autospace",
+        "specUrl": "https://drafts.csswg.org/css-text-4/#propdef-text-autospace",
+        "introduced": "2025-03-31"
+      },
+      {
+        "name": "text-box",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-box",
+        "specUrl": "https://drafts.csswg.org/css-inline-3/#text-box-shorthand",
+        "introduced": "2024-12-11"
+      },
+      {
+        "name": "text-box-edge",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-box-edge",
+        "specUrl": "https://drafts.csswg.org/css-inline-3/#text-box-edge",
+        "introduced": "2024-12-11"
+      },
+      {
+        "name": "text-box-trim",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-box-trim",
+        "specUrl": "https://drafts.csswg.org/css-inline-3/#text-box-trim",
+        "introduced": "2024-12-11"
+      },
+      {
+        "name": "text-combine-upright",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-combine-upright",
+        "specUrl": "https://drafts.csswg.org/css-writing-modes/#text-combine-upright",
+        "introduced": "2013-10-17"
+      },
+      {
+        "name": "text-decoration",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-decoration",
+        "specUrl": [
+          "https://drafts.csswg.org/css-text-decor-4/#text-decoration-property",
+          "https://svgwg.org/svg2-draft/text.html#TextDecorationProperties"
+        ],
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "text-decoration-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-decoration-color",
+        "specUrl": "https://drafts.csswg.org/css-text-decor/#text-decoration-color-property",
+        "introduced": "2015-02-24"
+      },
+      {
+        "name": "text-decoration-line",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-decoration-line",
+        "specUrl": "https://drafts.csswg.org/css-text-decor/#text-decoration-line-property",
+        "introduced": "2015-02-24"
+      },
+      {
+        "name": "text-decoration-skip",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-decoration-skip",
+        "specUrl": "https://drafts.csswg.org/css-text-decor-4/#text-decoration-skipping",
+        "introduced": "2017-03-09"
+      },
+      {
+        "name": "text-decoration-skip-ink",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-decoration-skip-ink",
+        "specUrl": "https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-ink-property",
+        "introduced": "2018-01-04"
+      },
+      {
+        "name": "text-decoration-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-decoration-style",
+        "specUrl": "https://drafts.csswg.org/css-text-decor/#text-decoration-style-property",
+        "introduced": "2015-02-24"
+      },
+      {
+        "name": "text-decoration-thickness",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-decoration-thickness",
+        "specUrl": "https://drafts.csswg.org/css-text-decor-4/#text-decoration-thickness-property",
+        "introduced": "2019-03-25"
+      },
+      {
+        "name": "text-emphasis",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-emphasis",
+        "specUrl": "https://drafts.csswg.org/css-text-decor/#text-emphasis-property",
+        "introduced": "2013-09-18"
+      },
+      {
+        "name": "text-emphasis-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-emphasis-color",
+        "specUrl": "https://drafts.csswg.org/css-text-decor/#text-emphasis-color-property",
+        "introduced": "2013-09-18"
+      },
+      {
+        "name": "text-emphasis-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-emphasis-position",
+        "specUrl": "https://drafts.csswg.org/css-text-decor/#text-emphasis-position-property",
+        "introduced": "2013-09-18"
+      },
+      {
+        "name": "text-emphasis-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-emphasis-style",
+        "specUrl": "https://drafts.csswg.org/css-text-decor/#text-emphasis-style-property",
+        "introduced": "2013-09-18"
+      },
+      {
+        "name": "text-indent",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-indent",
+        "specUrl": "https://drafts.csswg.org/css-text/#text-indent-property",
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "text-justify",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-justify",
+        "specUrl": "https://drafts.csswg.org/css-text/#text-justify-property",
+        "introduced": "2013-10-17"
+      },
+      {
+        "name": "text-orientation",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-orientation",
+        "specUrl": "https://drafts.csswg.org/css-writing-modes/#text-orientation",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "text-shadow",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-shadow",
+        "specUrl": "https://drafts.csswg.org/css-text-decor/#text-shadow-property",
+        "introduced": "2003-10-24"
+      },
+      {
+        "name": "text-size-adjust",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-size-adjust",
+        "specUrl": "https://drafts.csswg.org/css-size-adjust/#adjustment-control",
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "text-spacing-trim",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-spacing-trim",
+        "specUrl": "https://drafts.csswg.org/css-text-4/#text-spacing-trim-property",
+        "introduced": "2024-03-19"
+      },
+      {
+        "name": "text-transform",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-transform",
+        "specUrl": "https://drafts.csswg.org/css-text-4/#text-transform-property",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "text-underline-offset",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-underline-offset",
+        "specUrl": "https://drafts.csswg.org/css-text-decor-4/#underline-offset",
+        "introduced": "2019-03-25"
+      },
+      {
+        "name": "text-underline-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-underline-position",
+        "specUrl": "https://drafts.csswg.org/css-text-decor/#text-underline-position-property",
+        "introduced": "2001-08-27"
+      },
+      {
+        "name": "text-wrap",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-wrap",
+        "specUrl": "https://drafts.csswg.org/css-text-4/#text-wrap-shorthand",
+        "introduced": "2023-05-30"
+      },
+      {
+        "name": "text-wrap-mode",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-wrap-mode",
+        "specUrl": "https://drafts.csswg.org/css-text-4/#text-wrap-mode",
+        "introduced": "2024-03-05"
+      },
+      {
+        "name": "text-wrap-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-wrap-style",
+        "specUrl": "https://drafts.csswg.org/css-text-4/#text-wrap-style",
+        "introduced": "2024-03-19"
+      },
+      {
+        "name": "unicode-bidi",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/unicode-bidi",
+        "specUrl": "https://drafts.csswg.org/css-writing-modes/#unicode-bidi",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "vertical-align",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/vertical-align",
+        "specUrl": "https://drafts.csswg.org/css-inline/#propdef-vertical-align",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "white-space",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/white-space",
+        "specUrl": [
+          "https://drafts.csswg.org/css-text-4/#white-space-property",
+          "https://svgwg.org/svg2-draft/text.html#TextWhiteSpace"
+        ],
+        "introduced": "2000-06-28"
+      },
+      {
+        "name": "white-space-collapse",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/white-space-collapse",
+        "specUrl": "https://drafts.csswg.org/css-text-4/#white-space-collapsing",
+        "introduced": "2023-05-30"
+      },
+      {
+        "name": "word-break",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/word-break",
+        "specUrl": "https://drafts.csswg.org/css-text/#word-break-property",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "word-spacing",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/word-spacing",
+        "specUrl": [
+          "https://drafts.csswg.org/css-text/#word-spacing-property",
+          "https://svgwg.org/svg2-draft/text.html#WordSpacingProperty"
+        ],
+        "introduced": "1998-11-18"
+      },
+      {
+        "name": "writing-mode",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/writing-mode",
+        "specUrl": [
+          "https://drafts.csswg.org/css-writing-modes/#block-flow",
+          "https://svgwg.org/svg2-draft/text.html#WritingModeProperty"
+        ],
+        "introduced": "2011-03-14"
+      }
+    ]
+  },
+  {
+    "theme": "Color, Backgrounds & Decorative Effects",
+    "items": [
+      {
+        "name": "backdrop-filter",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/backdrop-filter",
+        "specUrl": "https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty",
+        "introduced": "2019-07-30"
+      },
+      {
+        "name": "background",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#background",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "background-attachment",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-attachment",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#background-attachment",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "background-clip",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-clip",
+        "specUrl": [
+          "https://drafts.csswg.org/css-backgrounds/#background-clip",
+          "https://drafts.csswg.org/css-backgrounds-4/#background-clip"
+        ],
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "background-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-color",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#background-color",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "background-image",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-image",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#background-image",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "background-origin",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-origin",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#background-origin",
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "background-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-position",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#background-position",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "background-position-x",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-position-x",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds-4/#background-position-longhands",
+        "introduced": "2001-08-27"
+      },
+      {
+        "name": "background-position-y",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-position-y",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds-4/#background-position-longhands",
+        "introduced": "2001-08-27"
+      },
+      {
+        "name": "background-repeat",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-repeat",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#background-repeat",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "background-repeat-x",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-backgrounds-4/#background-repeat-longhands",
+        "introduced": "2010-05-25"
+      },
+      {
+        "name": "background-repeat-y",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-backgrounds-4/#background-repeat-longhands",
+        "introduced": "2010-05-25"
+      },
+      {
+        "name": "background-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-size",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#background-size",
+        "introduced": "2009-09-01"
+      },
+      {
+        "name": "border",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#propdef-border",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-bottom",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-bottom",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-shorthands",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-bottom-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-bottom-color",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-color",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-bottom-left-radius",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-bottom-left-radius",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-radius",
+        "introduced": "2010-01-25"
+      },
+      {
+        "name": "border-bottom-right-radius",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-bottom-right-radius",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-radius",
+        "introduced": "2010-01-25"
+      },
+      {
+        "name": "border-bottom-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-bottom-style",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-style",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "border-bottom-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-bottom-width",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-width",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-image",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-image",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-image",
+        "introduced": "2010-12-16"
+      },
+      {
+        "name": "border-image-outset",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-image-outset",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-image-outset",
+        "introduced": "2011-10-25"
+      },
+      {
+        "name": "border-image-repeat",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-image-repeat",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-image-repeat",
+        "introduced": "2011-10-25"
+      },
+      {
+        "name": "border-image-slice",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-image-slice",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-image-slice",
+        "introduced": "2011-10-25"
+      },
+      {
+        "name": "border-image-source",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-image-source",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-image-source",
+        "introduced": "2011-10-25"
+      },
+      {
+        "name": "border-image-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-image-width",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-image-width",
+        "introduced": "2011-12-13"
+      },
+      {
+        "name": "border-left",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-left",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-shorthands",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-left-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-left-color",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-color",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-left-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-left-style",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-style",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "border-left-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-left-width",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-width",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-radius",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-radius",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-radius",
+        "introduced": "2010-01-25"
+      },
+      {
+        "name": "border-right",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-right",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-shorthands",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "border-right-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-right-color",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-color",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-right-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-right-style",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-style",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "border-right-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-right-width",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-width",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-style",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-style",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-top",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-top",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-shorthands",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-top-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-top-color",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-color",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-top-left-radius",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-top-left-radius",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-radius",
+        "introduced": "2010-01-25"
+      },
+      {
+        "name": "border-top-right-radius",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-top-right-radius",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-radius",
+        "introduced": "2010-01-25"
+      },
+      {
+        "name": "border-top-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-top-style",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-style",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "border-top-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-top-width",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-width",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-width",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#border-width",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "box-shadow",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-shadow",
+        "specUrl": "https://drafts.csswg.org/css-backgrounds/#box-shadow",
+        "introduced": "2010-03-02"
+      },
+      {
+        "name": "clip",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/clip",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#clip-property",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "clip-path",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/clip-path",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-clip-path",
+        "introduced": "2009-06-30"
+      },
+      {
+        "name": "clip-rule",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/clip-rule",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-clip-rule",
+        "introduced": "2009-06-30"
+      },
+      {
+        "name": "color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/color",
+        "specUrl": [
+          "https://drafts.csswg.org/css-color/#the-color-property",
+          "https://svgwg.org/svg2-draft/painting.html#ColorProperty"
+        ],
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "color-adjust",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-color-adjust-1/#color-adjust",
+        "introduced": "2016-08-02"
+      },
+      {
+        "name": "color-interpolation-filters",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/color-interpolation-filters",
+        "specUrl": "https://drafts.fxtf.org/filter-effects/#ColorInterpolationFiltersProperty",
+        "introduced": "2007-10-26"
+      },
+      {
+        "name": "color-scheme",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/color-scheme",
+        "specUrl": "https://drafts.csswg.org/css-color-adjust/#color-scheme-prop",
+        "introduced": "2019-09-19"
+      },
+      {
+        "name": "corner-block-end-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-block-end-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-block-end-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-block-start-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-block-start-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-block-start-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-bottom-left-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-bottom-left-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-bottom-left-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-bottom-right-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-bottom-right-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-bottom-right-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-bottom-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-bottom-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-bottom-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-end-end-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-end-end-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-end-end-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-end-start-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-end-start-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-end-start-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-inline-end-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-inline-end-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-inline-end-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-inline-start-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-inline-start-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-inline-start-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-left-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-left-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-left-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-right-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-right-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-right-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-start-end-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-start-end-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-start-end-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-start-start-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-start-start-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-start-start-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-top-left-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-top-left-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-top-left-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-top-right-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-top-right-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-top-right-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "corner-top-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/corner-top-shape",
+        "specUrl": "https://drafts.csswg.org/css-borders/#propdef-corner-top-shape",
+        "introduced": "2025-08-05"
+      },
+      {
+        "name": "dynamic-range-limit",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/dynamic-range-limit",
+        "specUrl": "https://drafts.csswg.org/css-color-hdr/#the-dynamic-range-limit-property",
+        "introduced": "2025-04-29"
+      },
+      {
+        "name": "filter",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/filter",
+        "specUrl": "https://drafts.fxtf.org/filter-effects/#FilterProperty",
+        "introduced": "2015-01-13"
+      },
+      {
+        "name": "flood-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/flood-color",
+        "specUrl": "https://drafts.fxtf.org/filter-effects/#FloodColorProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "flood-opacity",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/flood-opacity",
+        "specUrl": "https://drafts.fxtf.org/filter-effects/#FloodOpacityProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "forced-color-adjust",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/forced-color-adjust",
+        "specUrl": "https://drafts.csswg.org/css-color-adjust/#forced-color-adjust-prop",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "image-orientation",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/image-orientation",
+        "specUrl": "https://drafts.csswg.org/css-images/#the-image-orientation",
+        "introduced": "2013-12-10"
+      },
+      {
+        "name": "image-rendering",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/image-rendering",
+        "specUrl": [
+          "https://drafts.csswg.org/css-images/#the-image-rendering",
+          "https://svgwg.org/svg2-draft/painting.html#ImageRendering"
+        ],
+        "introduced": "2010-01-21"
+      },
+      {
+        "name": "lighting-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/lighting-color",
+        "specUrl": "https://drafts.fxtf.org/filter-effects/#LightingColorProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "mask",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask",
+        "introduced": "2017-04-19"
+      },
+      {
+        "name": "mask-border",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-border",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-border",
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "mask-border-outset",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-border-outset",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-border-outset",
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "mask-border-repeat",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-border-repeat",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-border-repeat",
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "mask-border-slice",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-border-slice",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-border-slice",
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "mask-border-source",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-border-source",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-border-source",
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "mask-border-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-border-width",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-border-width",
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "mask-clip",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-clip",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-clip",
+        "introduced": "2017-04-19"
+      },
+      {
+        "name": "mask-composite",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-composite",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-composite",
+        "introduced": "2017-04-19"
+      },
+      {
+        "name": "mask-image",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-image",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-image",
+        "introduced": "2013-07-02"
+      },
+      {
+        "name": "mask-mode",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-mode",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-mode",
+        "introduced": "2017-04-19"
+      },
+      {
+        "name": "mask-origin",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-origin",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-origin",
+        "introduced": "2017-04-19"
+      },
+      {
+        "name": "mask-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-position",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-position",
+        "introduced": "2017-04-19"
+      },
+      {
+        "name": "mask-repeat",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-repeat",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-repeat",
+        "introduced": "2017-04-19"
+      },
+      {
+        "name": "mask-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-size",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-size",
+        "introduced": "2017-04-19"
+      },
+      {
+        "name": "mask-type",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mask-type",
+        "specUrl": "https://drafts.fxtf.org/css-masking/#the-mask-type",
+        "introduced": "2013-01-10"
+      },
+      {
+        "name": "object-fit",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/object-fit",
+        "specUrl": "https://drafts.csswg.org/css-images/#the-object-fit",
+        "introduced": "2014-01-14"
+      },
+      {
+        "name": "object-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/object-position",
+        "specUrl": "https://drafts.csswg.org/css-images/#the-object-position",
+        "introduced": "2014-01-14"
+      },
+      {
+        "name": "object-view-box",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/object-view-box",
+        "specUrl": "https://drafts.csswg.org/css-images-5/#propdef-object-view-box",
+        "introduced": "2022-08-02"
+      },
+      {
+        "name": "opacity",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/opacity",
+        "specUrl": [
+          "https://drafts.csswg.org/css-color/#propdef-opacity",
+          "https://svgwg.org/svg2-draft/render.html#ObjectAndGroupOpacityProperties"
+        ],
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "print-color-adjust",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/print-color-adjust",
+        "specUrl": "https://drafts.csswg.org/css-color-adjust/#propdef-print-color-adjust",
+        "introduced": "2022-02-08"
+      },
+      {
+        "name": "shape-image-threshold",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/shape-image-threshold",
+        "specUrl": "https://drafts.csswg.org/css-shapes/#shape-image-threshold-property",
+        "introduced": "2014-08-26"
+      },
+      {
+        "name": "shape-margin",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/shape-margin",
+        "specUrl": "https://drafts.csswg.org/css-shapes/#shape-margin-property",
+        "introduced": "2014-08-26"
+      },
+      {
+        "name": "shape-outside",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/shape-outside",
+        "specUrl": "https://drafts.csswg.org/css-shapes/#shape-outside-property",
+        "introduced": "2014-08-26"
+      }
+    ]
+  },
+  {
+    "theme": "Box Model & Sizing",
+    "items": [
+      {
+        "name": "aspect-ratio",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/aspect-ratio",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#aspect-ratio",
+        "introduced": "2021-01-19"
+      },
+      {
+        "name": "box-sizing",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-sizing",
+        "specUrl": "https://drafts.csswg.org/css-sizing/#box-sizing",
+        "introduced": "2003-01-28"
+      },
+      {
+        "name": "column-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/column-width",
+        "specUrl": [
+          "https://drafts.csswg.org/css-sizing/#column-sizing",
+          "https://drafts.csswg.org/css-multicol/#cw"
+        ],
+        "introduced": "2011-04-12"
+      },
+      {
+        "name": "contain-intrinsic-block-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/contain-intrinsic-block-size",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-block-size",
+        "introduced": "2021-10-19"
+      },
+      {
+        "name": "contain-intrinsic-height",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/contain-intrinsic-height",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-height",
+        "introduced": "2021-10-19"
+      },
+      {
+        "name": "contain-intrinsic-inline-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/contain-intrinsic-inline-size",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-inline-size",
+        "introduced": "2021-10-19"
+      },
+      {
+        "name": "contain-intrinsic-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/contain-intrinsic-size",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-size",
+        "introduced": "2020-05-19"
+      },
+      {
+        "name": "contain-intrinsic-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/contain-intrinsic-width",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-width",
+        "introduced": "2021-10-19"
+      },
+      {
+        "name": "height",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/height",
+        "specUrl": [
+          "https://drafts.csswg.org/css-sizing/#preferred-size-properties",
+          "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "margin",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin",
+        "specUrl": "https://drafts.csswg.org/css-box/#margin",
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "margin-bottom",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-bottom",
+        "specUrl": "https://drafts.csswg.org/css-box/#margin-physical",
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "margin-left",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-left",
+        "specUrl": "https://drafts.csswg.org/css-box/#margin-physical",
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "margin-right",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-right",
+        "specUrl": "https://drafts.csswg.org/css-box/#margin-physical",
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "margin-top",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-top",
+        "specUrl": "https://drafts.csswg.org/css-box/#margin-physical",
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "margin-trim",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-trim",
+        "specUrl": "https://drafts.csswg.org/css-box-4/#margin-trim",
+        "introduced": "2023-03-27"
+      },
+      {
+        "name": "max-height",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/max-height",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#sizing-values",
+        "introduced": "2003-01-28"
+      },
+      {
+        "name": "max-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/max-width",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#sizing-values",
+        "introduced": "2000-06-28"
+      },
+      {
+        "name": "min-height",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/min-height",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#sizing-values",
+        "introduced": "2000-06-28"
+      },
+      {
+        "name": "min-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/min-width",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#sizing-values",
+        "introduced": "2000-06-28"
+      },
+      {
+        "name": "padding",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding",
+        "specUrl": "https://drafts.csswg.org/css-box/#padding-shorthand",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "padding-bottom",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-bottom",
+        "specUrl": "https://drafts.csswg.org/css-box/#padding-physical",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "padding-left",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-left",
+        "specUrl": "https://drafts.csswg.org/css-box/#padding-physical",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "padding-right",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-right",
+        "specUrl": "https://drafts.csswg.org/css-box/#padding-physical",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "padding-top",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-top",
+        "specUrl": "https://drafts.csswg.org/css-box/#padding-physical",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/width",
+        "specUrl": "https://drafts.csswg.org/css-sizing-4/#sizing-values",
+        "introduced": "1997-09-30"
+      }
+    ]
+  },
+  {
+    "theme": "Layout, Display & Positioning",
+    "items": [
+      {
+        "name": "align-content",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/align-content",
+        "specUrl": [
+          "https://drafts.csswg.org/css-align/#align-justify-content",
+          "https://drafts.csswg.org/css-flexbox/#align-content-property"
+        ],
+        "introduced": "2013-08-20"
+      },
+      {
+        "name": "align-items",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/align-items",
+        "specUrl": [
+          "https://drafts.csswg.org/css-align/#align-items-property",
+          "https://drafts.csswg.org/css-flexbox/#align-items-property"
+        ],
+        "introduced": "2013-04-02"
+      },
+      {
+        "name": "align-self",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/align-self",
+        "specUrl": [
+          "https://drafts.csswg.org/css-align/#align-self-property",
+          "https://drafts.csswg.org/css-flexbox/#align-items-property"
+        ],
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "anchor-name",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/anchor-name",
+        "specUrl": "https://drafts.csswg.org/css-anchor-position-1/#name",
+        "introduced": "2024-05-14"
+      },
+      {
+        "name": "anchor-scope",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-anchor-position-1/#propdef-anchor-scope",
+        "introduced": "2024-11-12"
+      },
+      {
+        "name": "block-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/block-size",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#dimension-properties",
+          "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+        ],
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-block",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-border-block",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-block-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-color",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-border-block-color",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-block-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-end",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-shorthands",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-block-end-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-end-color",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-color",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-block-end-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-end-style",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-style",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-block-end-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-end-width",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-width",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-block-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-start",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-shorthands",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-block-start-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-start-color",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-color",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-block-start-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-start-style",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-style",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-block-start-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-start-width",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-width",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-block-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-style",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-border-block-style",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-block-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-block-width",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-border-block-width",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-color",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#logical-shorthand-keyword",
+          "https://drafts.csswg.org/css-backgrounds/#border-color"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "border-end-end-radius",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-end-end-radius",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-radius-properties",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-end-start-radius",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-end-start-radius",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-radius-properties",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-inline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-border-inline",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-inline-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-color",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-border-inline-color",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-inline-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-end",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-shorthands",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-inline-end-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-end-color",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-color",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-inline-end-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-end-style",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-style",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-inline-end-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-end-width",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-width",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-inline-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-start",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-shorthands",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-inline-start-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-start-color",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-color",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-inline-start-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-start-style",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-style",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-inline-start-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-start-width",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-width",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "border-inline-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-style",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-border-inline-style",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-inline-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-inline-width",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-border-inline-width",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-start-end-radius",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-start-end-radius",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-radius-properties",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "border-start-start-radius",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-start-start-radius",
+        "specUrl": "https://drafts.csswg.org/css-logical/#border-radius-properties",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "bottom",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/bottom",
+        "specUrl": "https://drafts.csswg.org/css-position/#insets",
+        "introduced": "1999-03-18"
+      },
+      {
+        "name": "column-gap",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/column-gap",
+        "specUrl": [
+          "https://drafts.csswg.org/css-align/#column-row-gap",
+          "https://drafts.csswg.org/css-grid/#gutters",
+          "https://drafts.csswg.org/css-multicol/#column-gap"
+        ],
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "display",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/display",
+        "specUrl": [
+          "https://drafts.csswg.org/css-display/#the-display-properties",
+          "https://svgwg.org/svg2-draft/render.html#VisibilityControl"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "gap",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/gap",
+        "specUrl": "https://drafts.csswg.org/css-align/#gap-shorthand",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "inline-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/inline-size",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#dimension-properties",
+          "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+        ],
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "inset",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/inset",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-inset",
+          "https://drafts.csswg.org/css-position/#propdef-inset"
+        ],
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "inset-block",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/inset-block",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-inset-block",
+          "https://drafts.csswg.org/css-position/#propdef-inset-block"
+        ],
+        "introduced": "2018-10-23"
+      },
+      {
+        "name": "inset-block-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/inset-block-end",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-inset-block-end",
+          "https://drafts.csswg.org/css-position/#propdef-inset-block-end"
+        ],
+        "introduced": "2018-10-23"
+      },
+      {
+        "name": "inset-block-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/inset-block-start",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-inset-block-start",
+          "https://drafts.csswg.org/css-position/#propdef-inset-block-start"
+        ],
+        "introduced": "2018-10-23"
+      },
+      {
+        "name": "inset-inline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/inset-inline",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-inset-inline",
+          "https://drafts.csswg.org/css-position/#propdef-inset-inline"
+        ],
+        "introduced": "2018-10-23"
+      },
+      {
+        "name": "inset-inline-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/inset-inline-end",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-inset-inline-end",
+          "https://drafts.csswg.org/css-position/#propdef-inset-inline-end"
+        ],
+        "introduced": "2018-10-23"
+      },
+      {
+        "name": "inset-inline-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/inset-inline-start",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-inset-inline-start",
+          "https://drafts.csswg.org/css-position/#propdef-inset-inline-start"
+        ],
+        "introduced": "2018-10-23"
+      },
+      {
+        "name": "justify-content",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/justify-content",
+        "specUrl": [
+          "https://drafts.csswg.org/css-align/#align-justify-content",
+          "https://drafts.csswg.org/css-flexbox/#justify-content-property"
+        ],
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "justify-items",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/justify-items",
+        "specUrl": "https://drafts.csswg.org/css-align/#justify-items-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "justify-self",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/justify-self",
+        "specUrl": "https://drafts.csswg.org/css-align/#justify-self-property",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "left",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/left",
+        "specUrl": "https://drafts.csswg.org/css-position/#insets",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "margin-block",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-block",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-margin-block",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "margin-block-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-block-end",
+        "specUrl": "https://drafts.csswg.org/css-logical/#margin-properties",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "margin-block-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-block-start",
+        "specUrl": "https://drafts.csswg.org/css-logical/#margin-properties",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "margin-inline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-inline",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-margin-inline",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "margin-inline-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-inline-end",
+        "specUrl": "https://drafts.csswg.org/css-logical/#margin-properties",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "margin-inline-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/margin-inline-start",
+        "specUrl": "https://drafts.csswg.org/css-logical/#margin-properties",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "max-block-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/max-block-size",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-max-block-size",
+          "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+        ],
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "max-inline-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/max-inline-size",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-max-inline-size",
+          "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+        ],
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "min-block-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/min-block-size",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-min-block-size",
+          "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+        ],
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "min-inline-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/min-inline-size",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#propdef-min-inline-size",
+          "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+        ],
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "order",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/order",
+        "specUrl": "https://drafts.csswg.org/css-display/#order-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "overlay",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overlay",
+        "specUrl": "https://drafts.csswg.org/css-position-4/#overlay",
+        "introduced": "2023-09-12"
+      },
+      {
+        "name": "padding-block",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-block",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-padding-block",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "padding-block-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-block-end",
+        "specUrl": "https://drafts.csswg.org/css-logical/#padding-properties",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "padding-block-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-block-start",
+        "specUrl": "https://drafts.csswg.org/css-logical/#padding-properties",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "padding-inline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-inline",
+        "specUrl": "https://drafts.csswg.org/css-logical/#propdef-padding-inline",
+        "introduced": "2019-03-19"
+      },
+      {
+        "name": "padding-inline-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-inline-end",
+        "specUrl": "https://drafts.csswg.org/css-logical/#padding-properties",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "padding-inline-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/padding-inline-start",
+        "specUrl": "https://drafts.csswg.org/css-logical/#padding-properties",
+        "introduced": "2015-09-22"
+      },
+      {
+        "name": "page-break-after",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/page-break-after",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#page",
+          "https://drafts.csswg.org/css-break/#page-break-properties"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "page-break-before",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/page-break-before",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#page",
+          "https://drafts.csswg.org/css-break/#page-break-properties"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "place-content",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/place-content",
+        "specUrl": "https://drafts.csswg.org/css-align/#place-content",
+        "introduced": "2015-09-16"
+      },
+      {
+        "name": "place-items",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/place-items",
+        "specUrl": "https://drafts.csswg.org/css-align/#place-items-property",
+        "introduced": "2016-03-08"
+      },
+      {
+        "name": "place-self",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/place-self",
+        "specUrl": "https://drafts.csswg.org/css-align/#place-self-property",
+        "introduced": "2016-03-08"
+      },
+      {
+        "name": "position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/position",
+        "specUrl": "https://drafts.csswg.org/css-position/#position-property",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "position-anchor",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/position-anchor",
+        "specUrl": "https://drafts.csswg.org/css-anchor-position-1/#position-anchor",
+        "introduced": "2024-05-14"
+      },
+      {
+        "name": "position-area",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/position-area",
+        "specUrl": "https://drafts.csswg.org/css-anchor-position/#position-area",
+        "introduced": "2024-09-17"
+      },
+      {
+        "name": "position-try",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/position-try",
+        "specUrl": "https://drafts.csswg.org/css-anchor-position-1/#position-try-prop",
+        "introduced": "2024-05-14"
+      },
+      {
+        "name": "position-try-fallbacks",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/position-try-fallbacks",
+        "specUrl": "https://drafts.csswg.org/css-anchor-position-1/#position-try-fallbacks",
+        "introduced": "2024-08-20"
+      },
+      {
+        "name": "position-try-order",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/position-try-order",
+        "specUrl": "https://drafts.csswg.org/css-anchor-position-1/#position-try-order-property",
+        "introduced": "2024-05-14"
+      },
+      {
+        "name": "position-visibility",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/position-visibility",
+        "specUrl": "https://drafts.csswg.org/css-anchor-position-1/#position-visibility",
+        "introduced": "2024-05-14"
+      },
+      {
+        "name": "reading-flow",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/reading-flow",
+        "specUrl": "https://drafts.csswg.org/css-display-4/#reading-flow",
+        "introduced": "2025-05-27"
+      },
+      {
+        "name": "reading-order",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/reading-order",
+        "specUrl": "https://drafts.csswg.org/css-display-4/#propdef-reading-order",
+        "introduced": "2025-05-27"
+      },
+      {
+        "name": "right",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/right",
+        "specUrl": "https://drafts.csswg.org/css-position/#insets",
+        "introduced": "2000-07-06"
+      },
+      {
+        "name": "row-gap",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/row-gap",
+        "specUrl": "https://drafts.csswg.org/css-align/#column-row-gap",
+        "introduced": "2015-12-01"
+      },
+      {
+        "name": "text-align",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-align",
+        "specUrl": [
+          "https://drafts.csswg.org/css-logical/#text-align",
+          "https://drafts.csswg.org/css-text/#text-align-property"
+        ],
+        "introduced": "1996-08-13"
+      },
+      {
+        "name": "top",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/top",
+        "specUrl": "https://drafts.csswg.org/css-position/#insets",
+        "introduced": "1999-03-18"
+      },
+      {
+        "name": "visibility",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/visibility",
+        "specUrl": [
+          "https://drafts.csswg.org/css-display/#visibility",
+          "https://svgwg.org/svg2-draft/render.html#VisibilityControl"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "zoom",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/zoom",
+        "specUrl": "https://drafts.csswg.org/css-viewport/#zoom-property",
+        "introduced": "2000-07-06"
+      }
+    ]
+  },
+  {
+    "theme": "Flexbox Layout",
+    "items": [
+      {
+        "name": "flex",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/flex",
+        "specUrl": "https://drafts.csswg.org/css-flexbox/#flex-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "flex-basis",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/flex-basis",
+        "specUrl": "https://drafts.csswg.org/css-flexbox/#flex-basis-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "flex-direction",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/flex-direction",
+        "specUrl": "https://drafts.csswg.org/css-flexbox/#flex-direction-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "flex-flow",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/flex-flow",
+        "specUrl": "https://drafts.csswg.org/css-flexbox/#flex-flow-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "flex-grow",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/flex-grow",
+        "specUrl": "https://drafts.csswg.org/css-flexbox/#flex-grow-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "flex-shrink",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/flex-shrink",
+        "specUrl": "https://drafts.csswg.org/css-flexbox/#flex-shrink-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "flex-wrap",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/flex-wrap",
+        "specUrl": "https://drafts.csswg.org/css-flexbox/#flex-wrap-property",
+        "introduced": "2013-08-20"
+      }
+    ]
+  },
+  {
+    "theme": "Grid Layout",
+    "items": [
+      {
+        "name": "grid",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid",
+        "specUrl": "https://drafts.csswg.org/css-grid/#grid-shorthand",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-area",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-area",
+        "specUrl": "https://drafts.csswg.org/css-grid/#propdef-grid-area",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-auto-columns",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-auto-columns",
+        "specUrl": "https://drafts.csswg.org/css-grid/#auto-tracks",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "grid-auto-flow",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-auto-flow",
+        "specUrl": "https://drafts.csswg.org/css-grid/#grid-auto-flow-property",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-auto-rows",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-auto-rows",
+        "specUrl": "https://drafts.csswg.org/css-grid/#auto-tracks",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "grid-column",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-column",
+        "specUrl": "https://drafts.csswg.org/css-grid/#placement-shorthands",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-column-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-column-end",
+        "specUrl": "https://drafts.csswg.org/css-grid/#line-placement",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-column-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-column-start",
+        "specUrl": "https://drafts.csswg.org/css-grid/#line-placement",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-row",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-row",
+        "specUrl": "https://drafts.csswg.org/css-grid/#placement-shorthands",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-row-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-row-end",
+        "specUrl": "https://drafts.csswg.org/css-grid/#line-placement",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-row-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-row-start",
+        "specUrl": "https://drafts.csswg.org/css-grid/#line-placement",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-template",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-template",
+        "specUrl": "https://drafts.csswg.org/css-grid/#explicit-grid-shorthand",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-template-areas",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-template-areas",
+        "specUrl": "https://drafts.csswg.org/css-grid/#grid-template-areas-property",
+        "introduced": "2017-03-07"
+      },
+      {
+        "name": "grid-template-columns",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-template-columns",
+        "specUrl": [
+          "https://drafts.csswg.org/css-grid/#track-sizing",
+          "https://drafts.csswg.org/css-grid/#subgrids"
+        ],
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "grid-template-rows",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/grid-template-rows",
+        "specUrl": [
+          "https://drafts.csswg.org/css-grid/#track-sizing",
+          "https://drafts.csswg.org/css-grid/#subgrids"
+        ],
+        "introduced": "2012-10-26"
+      }
+    ]
+  },
+  {
+    "theme": "Multi-column & Fragmentation",
+    "items": [
+      {
+        "name": "box-decoration-break",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-decoration-break",
+        "specUrl": "https://drafts.csswg.org/css-break/#break-decoration",
+        "introduced": "2013-09-18"
+      },
+      {
+        "name": "break-after",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/break-after",
+        "specUrl": [
+          "https://drafts.csswg.org/css-break/#break-between",
+          "https://drafts.csswg.org/css-regions/#region-flow-break",
+          "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
+        ],
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "break-before",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/break-before",
+        "specUrl": [
+          "https://drafts.csswg.org/css-break/#break-between",
+          "https://drafts.csswg.org/css-regions/#region-flow-break",
+          "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
+        ],
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "break-inside",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/break-inside",
+        "specUrl": [
+          "https://drafts.csswg.org/css-break/#break-within",
+          "https://drafts.csswg.org/css-regions/#region-flow-break",
+          "https://drafts.csswg.org/css-multicol/#break-before-break-after-break-inside"
+        ],
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "column-count",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/column-count",
+        "specUrl": "https://drafts.csswg.org/css-multicol/#cc",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "column-fill",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/column-fill",
+        "specUrl": "https://drafts.csswg.org/css-multicol/#cf",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "column-rule",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/column-rule",
+        "specUrl": "https://drafts.csswg.org/css-multicol/#column-rule",
+        "introduced": "2011-04-12"
+      },
+      {
+        "name": "column-rule-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/column-rule-color",
+        "specUrl": "https://drafts.csswg.org/css-multicol/#crc",
+        "introduced": "2011-04-12"
+      },
+      {
+        "name": "column-rule-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/column-rule-style",
+        "specUrl": "https://drafts.csswg.org/css-multicol/#crs",
+        "introduced": "2011-04-12"
+      },
+      {
+        "name": "column-rule-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/column-rule-width",
+        "specUrl": "https://drafts.csswg.org/css-multicol/#crw",
+        "introduced": "2011-04-12"
+      },
+      {
+        "name": "column-span",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/column-span",
+        "specUrl": "https://drafts.csswg.org/css-multicol/#column-span",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "columns",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/columns",
+        "specUrl": "https://drafts.csswg.org/css-multicol/#columns",
+        "introduced": "2011-04-12"
+      },
+      {
+        "name": "orphans",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/orphans",
+        "specUrl": "https://drafts.csswg.org/css-break/#widows-orphans",
+        "introduced": "2005-04-15"
+      },
+      {
+        "name": "page",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/page",
+        "specUrl": "https://drafts.csswg.org/css-page/#propdef-page",
+        "introduced": "2003-06-23"
+      },
+      {
+        "name": "page-break-inside",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/page-break-inside",
+        "specUrl": "https://drafts.csswg.org/css-break/#page-break-properties",
+        "introduced": "2003-01-28"
+      },
+      {
+        "name": "widows",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/widows",
+        "specUrl": [
+          "https://drafts.csswg.org/css-break/#widows-orphans",
+          "https://drafts.csswg.org/css-multicol/#filling-columns"
+        ],
+        "introduced": "2005-04-15"
+      }
+    ]
+  },
+  {
+    "theme": "Scroll & Overflow",
+    "items": [
+      {
+        "name": "line-clamp",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/line-clamp",
+        "specUrl": "https://drafts.csswg.org/css-overflow-4/#propdef-line-clamp",
+        "introduced": "2010-06-07"
+      },
+      {
+        "name": "overflow",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overflow",
+        "specUrl": [
+          "https://drafts.csswg.org/css-overflow/#propdef-overflow",
+          "https://svgwg.org/svg2-draft/render.html#OverflowAndClipProperties"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "overflow-anchor",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overflow-anchor",
+        "specUrl": "https://drafts.csswg.org/css-scroll-anchoring/#exclusion-api",
+        "introduced": "2017-01-25"
+      },
+      {
+        "name": "overflow-block",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overflow-block",
+        "specUrl": "https://drafts.csswg.org/css-overflow/#overflow-control",
+        "introduced": "2019-09-03"
+      },
+      {
+        "name": "overflow-clip-margin",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overflow-clip-margin",
+        "specUrl": "https://drafts.csswg.org/css-overflow/#overflow-clip-margin",
+        "introduced": "2021-04-13"
+      },
+      {
+        "name": "overflow-inline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overflow-inline",
+        "specUrl": "https://drafts.csswg.org/css-overflow/#overflow-control",
+        "introduced": "2019-09-03"
+      },
+      {
+        "name": "overflow-x",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overflow-x",
+        "specUrl": "https://drafts.csswg.org/css-overflow/#overflow-properties",
+        "introduced": "1999-03-18"
+      },
+      {
+        "name": "overflow-y",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overflow-y",
+        "specUrl": "https://drafts.csswg.org/css-overflow/#overflow-properties",
+        "introduced": "1999-03-18"
+      },
+      {
+        "name": "overscroll-behavior",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overscroll-behavior",
+        "specUrl": "https://drafts.csswg.org/css-overscroll/#overscroll-behavior-properties",
+        "introduced": "2017-12-05"
+      },
+      {
+        "name": "overscroll-behavior-block",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overscroll-behavior-block",
+        "specUrl": "https://drafts.csswg.org/css-overscroll/#overscroll-behavior-longhands-logical",
+        "introduced": "2019-09-10"
+      },
+      {
+        "name": "overscroll-behavior-inline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overscroll-behavior-inline",
+        "specUrl": "https://drafts.csswg.org/css-overscroll/#overscroll-behavior-longhands-logical",
+        "introduced": "2019-09-10"
+      },
+      {
+        "name": "overscroll-behavior-x",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overscroll-behavior-x",
+        "specUrl": "https://drafts.csswg.org/css-overscroll/#overscroll-behavior-longhands-physical",
+        "introduced": "2017-12-05"
+      },
+      {
+        "name": "overscroll-behavior-y",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overscroll-behavior-y",
+        "specUrl": "https://drafts.csswg.org/css-overscroll/#overscroll-behavior-longhands-physical",
+        "introduced": "2017-12-05"
+      },
+      {
+        "name": "scroll-behavior",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-behavior",
+        "specUrl": "https://drafts.csswg.org/css-overflow/#smooth-scrolling",
+        "introduced": "2015-02-24"
+      },
+      {
+        "name": "scroll-initial-target",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap-2/#propdef-scroll-initial-target",
+        "introduced": "2025-02-04"
+      },
+      {
+        "name": "scroll-margin",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#scroll-margin",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-block",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-block",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-margin-block",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-block-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-block-end",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-logical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-block-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-block-start",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-logical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-bottom",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-bottom",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-physical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-inline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-inline",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-margin-inline",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-inline-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-inline-end",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-logical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-inline-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-inline-start",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-logical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-left",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-left",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-physical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-right",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-right",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-physical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-margin-top",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-margin-top",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#margin-longhands-physical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-marker-group",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-marker-group",
+        "specUrl": "https://drafts.csswg.org/css-overflow-5/#scroll-marker-group-property",
+        "introduced": "2025-04-01"
+      },
+      {
+        "name": "scroll-padding",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#scroll-padding",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-block",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-block",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-padding-block",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-block-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-block-end",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-logical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-block-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-block-start",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-logical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-bottom",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-bottom",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-physical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-inline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-inline",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#propdef-scroll-padding-inline",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-inline-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-inline-end",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-logical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-inline-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-inline-start",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-logical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-left",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-left",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-physical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-right",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-right",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-physical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-padding-top",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-padding-top",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#padding-longhands-physical",
+        "introduced": "2018-09-04"
+      },
+      {
+        "name": "scroll-snap-align",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-snap-align",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#scroll-snap-align",
+        "introduced": "2017-09-19"
+      },
+      {
+        "name": "scroll-snap-stop",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-snap-stop",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#scroll-snap-stop",
+        "introduced": "2019-06-04"
+      },
+      {
+        "name": "scroll-snap-type",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-snap-type",
+        "specUrl": "https://drafts.csswg.org/css-scroll-snap/#scroll-snap-type",
+        "introduced": "2012-10-26"
+      },
+      {
+        "name": "scroll-target-group",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-target-group",
+        "specUrl": "https://drafts.csswg.org/css-overflow-5/#scroll-target-group",
+        "introduced": "2025-09-02"
+      },
+      {
+        "name": "scrollbar-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scrollbar-color",
+        "specUrl": "https://drafts.csswg.org/css-scrollbars/#scrollbar-color",
+        "introduced": "2018-12-11"
+      },
+      {
+        "name": "scrollbar-gutter",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scrollbar-gutter",
+        "specUrl": "https://drafts.csswg.org/css-overflow/#scrollbar-gutter-property",
+        "introduced": "2021-09-21"
+      },
+      {
+        "name": "scrollbar-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scrollbar-width",
+        "specUrl": "https://drafts.csswg.org/css-scrollbars/#scrollbar-width",
+        "introduced": "2018-12-11"
+      },
+      {
+        "name": "text-overflow",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-overflow",
+        "specUrl": [
+          "https://drafts.csswg.org/css-overflow/#text-overflow",
+          "https://svgwg.org/svg2-draft/text.html#TextOverflowProperty"
+        ],
+        "introduced": "2001-08-27"
+      }
+    ]
+  },
+  {
+    "theme": "Animations, Transitions & View Transitions",
+    "items": [
+      {
+        "name": "animation",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation",
+        "specUrl": "https://drafts.csswg.org/css-animations/#animation",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "animation-composition",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-composition",
+        "specUrl": "https://drafts.csswg.org/css-animations-2/#animation-composition",
+        "introduced": "2022-09-12"
+      },
+      {
+        "name": "animation-delay",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-delay",
+        "specUrl": "https://drafts.csswg.org/css-animations/#animation-delay",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "animation-direction",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-direction",
+        "specUrl": "https://drafts.csswg.org/css-animations/#animation-direction",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "animation-duration",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-duration",
+        "specUrl": "https://drafts.csswg.org/css-animations/#animation-duration",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "animation-fill-mode",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-fill-mode",
+        "specUrl": "https://drafts.csswg.org/css-animations/#animation-fill-mode",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "animation-iteration-count",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-iteration-count",
+        "specUrl": "https://drafts.csswg.org/css-animations/#animation-iteration-count",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "animation-name",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-name",
+        "specUrl": "https://drafts.csswg.org/css-animations/#animation-name",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "animation-play-state",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-play-state",
+        "specUrl": "https://drafts.csswg.org/css-animations/#animation-play-state",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "animation-timeline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-timeline",
+        "specUrl": "https://drafts.csswg.org/css-animations-2/#animation-timeline",
+        "introduced": "2023-02-14"
+      },
+      {
+        "name": "animation-timing-function",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-timing-function",
+        "specUrl": "https://drafts.csswg.org/css-animations/#animation-timing-function",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "transition",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transition",
+        "specUrl": "https://drafts.csswg.org/css-transitions/#transition-shorthand-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "transition-behavior",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transition-behavior",
+        "specUrl": "https://drafts.csswg.org/css-transitions-2/#transition-behavior-property",
+        "introduced": "2023-09-12"
+      },
+      {
+        "name": "transition-delay",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transition-delay",
+        "specUrl": "https://drafts.csswg.org/css-transitions/#transition-delay-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "transition-duration",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transition-duration",
+        "specUrl": "https://drafts.csswg.org/css-transitions/#transition-duration-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "transition-property",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transition-property",
+        "specUrl": "https://drafts.csswg.org/css-transitions/#transition-property-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "transition-timing-function",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transition-timing-function",
+        "specUrl": "https://drafts.csswg.org/css-transitions/#transition-timing-function-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "view-transition-class",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/view-transition-class",
+        "specUrl": "https://drafts.csswg.org/css-view-transitions-2/#view-transition-class-prop",
+        "introduced": "2024-05-14"
+      },
+      {
+        "name": "view-transition-group",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-view-transitions-2/#view-transition-group-prop",
+        "introduced": "2025-09-02"
+      },
+      {
+        "name": "view-transition-name",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/view-transition-name",
+        "specUrl": "https://drafts.csswg.org/css-view-transitions/#view-transition-name-prop",
+        "introduced": "2023-03-01"
+      }
+    ]
+  },
+  {
+    "theme": "Transforms & Motion",
+    "items": [
+      {
+        "name": "backface-visibility",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/backface-visibility",
+        "specUrl": "https://drafts.csswg.org/css-transforms-2/#backface-visibility-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "perspective",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/perspective",
+        "specUrl": "https://drafts.csswg.org/css-transforms-2/#perspective-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "perspective-origin",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/perspective-origin",
+        "specUrl": "https://drafts.csswg.org/css-transforms-2/#perspective-origin-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "rotate",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/rotate",
+        "specUrl": "https://drafts.csswg.org/css-transforms-2/#individual-transforms",
+        "introduced": "2020-01-07"
+      },
+      {
+        "name": "scale",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scale",
+        "specUrl": "https://drafts.csswg.org/css-transforms-2/#individual-transforms",
+        "introduced": "2020-01-07"
+      },
+      {
+        "name": "transform",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transform",
+        "specUrl": [
+          "https://drafts.csswg.org/css-transforms-2/#transform-functions",
+          "https://drafts.csswg.org/css-transforms/#transform-property",
+          "https://svgwg.org/svg2-draft/coords.html#TransformProperty"
+        ],
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "transform-box",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transform-box",
+        "specUrl": "https://drafts.csswg.org/css-transforms/#transform-box",
+        "introduced": "2017-08-08"
+      },
+      {
+        "name": "transform-origin",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transform-origin",
+        "specUrl": "https://drafts.csswg.org/css-transforms/#transform-origin-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "transform-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/transform-style",
+        "specUrl": "https://drafts.csswg.org/css-transforms-2/#transform-style-property",
+        "introduced": "2012-10-09"
+      },
+      {
+        "name": "translate",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/translate",
+        "specUrl": "https://drafts.csswg.org/css-transforms-2/#individual-transforms",
+        "introduced": "2020-01-07"
+      },
+      {
+        "name": "will-change",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/will-change",
+        "specUrl": "https://drafts.csswg.org/css-will-change/#will-change",
+        "introduced": "2014-07-16"
+      }
+    ]
+  },
+  {
+    "theme": "Generated Content & Lists",
+    "items": [
+      {
+        "name": "content",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/content",
+        "specUrl": "https://drafts.csswg.org/css-content/#content-property",
+        "introduced": "2000-06-28"
+      },
+      {
+        "name": "counter-increment",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/counter-increment",
+        "specUrl": "https://drafts.csswg.org/css-lists/#increment-set",
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "counter-reset",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/counter-reset",
+        "specUrl": "https://drafts.csswg.org/css-lists/#counter-reset",
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "counter-set",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/counter-set",
+        "specUrl": "https://drafts.csswg.org/css-lists/#propdef-counter-set",
+        "introduced": "2019-07-09"
+      },
+      {
+        "name": "list-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/list-style",
+        "specUrl": "https://drafts.csswg.org/css-lists/#list-style-property",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "list-style-image",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/list-style-image",
+        "specUrl": "https://drafts.csswg.org/css-lists/#image-markers",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "list-style-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/list-style-position",
+        "specUrl": "https://drafts.csswg.org/css-lists/#list-style-position-property",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "list-style-type",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/list-style-type",
+        "specUrl": [
+          "https://drafts.csswg.org/css-lists/#text-markers",
+          "https://drafts.csswg.org/css-counter-styles/#extending-css2"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "quotes",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/quotes",
+        "specUrl": "https://drafts.csswg.org/css-content/#quotes",
+        "introduced": "2000-06-28"
+      }
+    ]
+  },
+  {
+    "theme": "Custom Properties & Values",
+    "items": [
+      {
+        "name": "all",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/all",
+        "specUrl": "https://drafts.csswg.org/css-cascade/#all-shorthand",
+        "introduced": "2014-02-04"
+      },
+      {
+        "name": "container",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/container",
+        "specUrl": "https://drafts.csswg.org/css-conditional-5/#container-shorthand",
+        "introduced": "2022-09-01"
+      },
+      {
+        "name": "container-name",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/container-name",
+        "specUrl": "https://drafts.csswg.org/css-conditional-5/#container-name",
+        "introduced": "2022-09-01"
+      },
+      {
+        "name": "container-type",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/container-type",
+        "specUrl": "https://drafts.csswg.org/css-conditional-5/#container-type",
+        "introduced": "2022-09-01"
+      },
+      {
+        "name": "custom-property",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/--*",
+        "specUrl": "https://drafts.csswg.org/css-variables/#defining-variables",
+        "introduced": "2014-07-22"
+      },
+      {
+        "name": "interpolate-size",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/interpolate-size",
+        "specUrl": "https://drafts.csswg.org/css-values-5/#interpolate-size",
+        "introduced": "2024-09-17"
+      },
+      {
+        "name": "touch-action",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/touch-action",
+        "specUrl": [
+          "https://compat.spec.whatwg.org/#touch-action",
+          "https://w3c.github.io/pointerevents/#the-touch-action-css-property"
+        ],
+        "introduced": "2013-10-17"
+      }
+    ]
+  },
+  {
+    "theme": "Interaction & UI",
+    "items": [
+      {
+        "name": "accent-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/accent-color",
+        "specUrl": "https://drafts.csswg.org/css-ui/#widget-accent",
+        "introduced": "2021-08-31"
+      },
+      {
+        "name": "appearance",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/appearance",
+        "specUrl": "https://drafts.csswg.org/css-ui/#appearance-switching",
+        "introduced": "2020-07-16"
+      },
+      {
+        "name": "caret-animation",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/caret-animation",
+        "specUrl": "https://drafts.csswg.org/css-ui/#propdef-caret-animation",
+        "introduced": "2025-09-02"
+      },
+      {
+        "name": "caret-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/caret-color",
+        "specUrl": "https://drafts.csswg.org/css-ui/#caret-color",
+        "introduced": "2017-03-09"
+      },
+      {
+        "name": "caret-shape",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/caret-shape",
+        "specUrl": "https://drafts.csswg.org/css-ui/#propdef-caret-shape",
+        "introduced": "2025-09-02"
+      },
+      {
+        "name": "cursor",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/cursor",
+        "specUrl": "https://drafts.csswg.org/css-ui/#cursor",
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "field-sizing",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/field-sizing",
+        "specUrl": "https://drafts.csswg.org/css-forms-1/#propdef-field-sizing",
+        "introduced": "2024-03-19"
+      },
+      {
+        "name": "ime-mode",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-ui/#input-method-editor",
+        "introduced": "1999-03-18"
+      },
+      {
+        "name": "interactivity",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/interactivity",
+        "specUrl": "https://drafts.csswg.org/css-ui-4/#propdef-interactivity",
+        "introduced": "2025-04-01"
+      },
+      {
+        "name": "interest-delay",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-ui-4/#propdef-interest-delay",
+        "introduced": "2025-10-28"
+      },
+      {
+        "name": "interest-delay-end",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-ui-4/#propdef-interest-delay-end",
+        "introduced": "2025-10-28"
+      },
+      {
+        "name": "interest-delay-start",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.csswg.org/css-ui-4/#propdef-interest-delay-start",
+        "introduced": "2025-10-28"
+      },
+      {
+        "name": "outline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/outline",
+        "specUrl": "https://drafts.csswg.org/css-ui/#outline",
+        "introduced": "2009-03-19"
+      },
+      {
+        "name": "outline-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/outline-color",
+        "specUrl": "https://drafts.csswg.org/css-ui/#outline-color",
+        "introduced": "2003-01-28"
+      },
+      {
+        "name": "outline-offset",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/outline-offset",
+        "specUrl": "https://drafts.csswg.org/css-ui/#outline-offset",
+        "introduced": "2004-02-02"
+      },
+      {
+        "name": "outline-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/outline-style",
+        "specUrl": "https://drafts.csswg.org/css-ui/#outline-style",
+        "introduced": "2003-01-28"
+      },
+      {
+        "name": "outline-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/outline-width",
+        "specUrl": "https://drafts.csswg.org/css-ui/#outline-width",
+        "introduced": "2003-01-28"
+      },
+      {
+        "name": "pointer-events",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/pointer-events",
+        "specUrl": [
+          "https://drafts.csswg.org/css-ui/#pointer-events-control",
+          "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"
+        ],
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "resize",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/resize",
+        "specUrl": "https://drafts.csswg.org/css-ui/#resize",
+        "introduced": "2007-10-26"
+      },
+      {
+        "name": "user-select",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/user-select",
+        "specUrl": "https://drafts.csswg.org/css-ui/#content-selection",
+        "introduced": "2007-10-26"
+      }
+    ]
+  },
+  {
+    "theme": "Containment & Viewport",
+    "items": [
+      {
+        "name": "contain",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/contain",
+        "specUrl": "https://drafts.csswg.org/css-contain/#contain-property",
+        "introduced": "2016-07-20"
+      },
+      {
+        "name": "content-visibility",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/content-visibility",
+        "specUrl": "https://drafts.csswg.org/css-contain/#content-visibility",
+        "introduced": "2020-08-25"
+      }
+    ]
+  },
+  {
+    "theme": "Speech & Accessibility",
+    "items": [
+      {
+        "name": "speak-as",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/speak-as",
+        "specUrl": "https://drafts.csswg.org/css-speech-1/#speaking-props-speak-as",
+        "introduced": "2018-03-29"
+      }
+    ]
+  },
+  {
+    "theme": "SVG & Vector Graphics",
+    "items": [
+      {
+        "name": "background-blend-mode",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/background-blend-mode",
+        "specUrl": "https://drafts.fxtf.org/compositing/#background-blend-mode",
+        "introduced": "2014-05-20"
+      },
+      {
+        "name": "color-interpolation",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/color-interpolation",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "cx",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/cx",
+        "specUrl": "https://svgwg.org/svg2-draft/geometry.html#CX",
+        "introduced": "2015-05-19"
+      },
+      {
+        "name": "cy",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/cy",
+        "specUrl": "https://svgwg.org/svg2-draft/geometry.html#CY",
+        "introduced": "2015-05-19"
+      },
+      {
+        "name": "d",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/d",
+        "specUrl": "https://svgwg.org/svg2-draft/paths.html#TheDProperty",
+        "introduced": "2016-07-20"
+      },
+      {
+        "name": "fill",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/fill",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#FillProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "fill-opacity",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/fill-opacity",
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#fill-opacity",
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "fill-rule",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/fill-rule",
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#fill-rule",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "isolation",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/isolation",
+        "specUrl": "https://drafts.fxtf.org/compositing/#isolation",
+        "introduced": "2014-09-17"
+      },
+      {
+        "name": "marker",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/marker",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#MarkerShorthand",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "marker-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/marker-end",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "marker-mid",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/marker-mid",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "marker-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/marker-start",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "mix-blend-mode",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/mix-blend-mode",
+        "specUrl": "https://drafts.fxtf.org/compositing/#mix-blend-mode",
+        "introduced": "2014-09-02"
+      },
+      {
+        "name": "offset",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/offset",
+        "specUrl": "https://drafts.fxtf.org/motion/#offset-shorthand",
+        "introduced": "2016-12-01"
+      },
+      {
+        "name": "offset-anchor",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/offset-anchor",
+        "specUrl": "https://drafts.fxtf.org/motion/#offset-anchor-property",
+        "introduced": "2020-01-07"
+      },
+      {
+        "name": "offset-distance",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/offset-distance",
+        "specUrl": "https://drafts.fxtf.org/motion/#offset-distance-property",
+        "introduced": "2016-12-01"
+      },
+      {
+        "name": "offset-path",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/offset-path",
+        "specUrl": "https://drafts.fxtf.org/motion/#offset-path-property",
+        "introduced": "2016-12-01"
+      },
+      {
+        "name": "offset-position",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/offset-position",
+        "specUrl": "https://drafts.fxtf.org/motion/#offset-position-property",
+        "introduced": "2022-09-12"
+      },
+      {
+        "name": "offset-rotate",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/offset-rotate",
+        "specUrl": "https://drafts.fxtf.org/motion/#offset-rotate-property",
+        "introduced": "2017-01-25"
+      },
+      {
+        "name": "paint-order",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/paint-order",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty",
+        "introduced": "2017-09-19"
+      },
+      {
+        "name": "r",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/r",
+        "specUrl": "https://svgwg.org/svg2-draft/geometry.html#R",
+        "introduced": "2015-05-19"
+      },
+      {
+        "name": "rx",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/rx",
+        "specUrl": "https://svgwg.org/svg2-draft/geometry.html#RX",
+        "introduced": "2015-05-19"
+      },
+      {
+        "name": "ry",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/ry",
+        "specUrl": "https://svgwg.org/svg2-draft/geometry.html#RY",
+        "introduced": "2015-05-19"
+      },
+      {
+        "name": "shape-rendering",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/shape-rendering",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#ShapeRendering",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "stop-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stop-color",
+        "specUrl": "https://svgwg.org/svg2-draft/pservers.html#StopColorProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "stop-opacity",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stop-opacity",
+        "specUrl": "https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "stroke",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stroke",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#StrokeProperty",
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "stroke-color",
+        "mdnUrl": null,
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#stroke-color",
+        "introduced": "2018-03-29"
+      },
+      {
+        "name": "stroke-dasharray",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stroke-dasharray",
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#stroke-dasharray",
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "stroke-dashoffset",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stroke-dashoffset",
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#stroke-dashoffset",
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "stroke-linecap",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stroke-linecap",
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#stroke-linecap",
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "stroke-linejoin",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stroke-linejoin",
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#stroke-linejoin",
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "stroke-miterlimit",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stroke-miterlimit",
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#stroke-miterlimit",
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "stroke-opacity",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stroke-opacity",
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#stroke-opacity",
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "stroke-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stroke-width",
+        "specUrl": "https://drafts.fxtf.org/fill-stroke-3/#stroke-width",
+        "introduced": "2005-11-29"
+      },
+      {
+        "name": "text-anchor",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-anchor",
+        "specUrl": "https://svgwg.org/svg2-draft/text.html#TextAnchorProperty",
+        "introduced": "2008-06-17"
+      },
+      {
+        "name": "text-rendering",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-rendering",
+        "specUrl": "https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty",
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "vector-effect",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/vector-effect",
+        "specUrl": "https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty",
+        "introduced": "2010-09-02"
+      },
+      {
+        "name": "x",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/x",
+        "specUrl": "https://svgwg.org/svg2-draft/geometry.html#X",
+        "introduced": "2015-04-14"
+      },
+      {
+        "name": "y",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/y",
+        "specUrl": "https://svgwg.org/svg2-draft/geometry.html#Y",
+        "introduced": "2015-04-14"
+      }
+    ]
+  },
+  {
+    "theme": "Legacy & Miscellaneous",
+    "items": [
+      {
+        "name": "-moz-float-edge",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-moz-float-edge",
+        "specUrl": null,
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "-moz-force-broken-image-icon",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-moz-force-broken-image-icon",
+        "specUrl": null,
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "-moz-orient",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-moz-orient",
+        "specUrl": null,
+        "introduced": "2011-08-16"
+      },
+      {
+        "name": "-moz-user-focus",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-moz-user-focus",
+        "specUrl": null,
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "-moz-user-input",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-moz-user-input",
+        "specUrl": null,
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "-webkit-app-region",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2013-01-10"
+      },
+      {
+        "name": "-webkit-border-before",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-border-before",
+        "specUrl": null,
+        "introduced": "2010-12-02"
+      },
+      {
+        "name": "-webkit-border-horizontal-spacing",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-border-vertical-spacing",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-box-reflect",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-box-reflect",
+        "specUrl": null,
+        "introduced": "2009-06-08"
+      },
+      {
+        "name": "-webkit-column-axis",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2012-02-08"
+      },
+      {
+        "name": "-webkit-column-break-after",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-column-break-before",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-column-break-inside",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-column-progression",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2012-09-25"
+      },
+      {
+        "name": "-webkit-cursor-visibility",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2013-09-18"
+      },
+      {
+        "name": "-webkit-hyphenate-limit-after",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2011-04-27"
+      },
+      {
+        "name": "-webkit-hyphenate-limit-before",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2011-04-27"
+      },
+      {
+        "name": "-webkit-hyphenate-limit-lines",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2011-12-13"
+      },
+      {
+        "name": "-webkit-line-align",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2012-05-15"
+      },
+      {
+        "name": "-webkit-line-box-contain",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2011-06-07"
+      },
+      {
+        "name": "-webkit-line-grid",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2012-02-08"
+      },
+      {
+        "name": "-webkit-line-snap",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2012-05-15"
+      },
+      {
+        "name": "-webkit-locale",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2011-04-27"
+      },
+      {
+        "name": "-webkit-logical-height",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2010-12-02"
+      },
+      {
+        "name": "-webkit-logical-width",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2010-12-02"
+      },
+      {
+        "name": "-webkit-margin-after",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2010-12-02"
+      },
+      {
+        "name": "-webkit-margin-before",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2010-12-02"
+      },
+      {
+        "name": "-webkit-mask-box-image",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-mask-box-image",
+        "specUrl": null,
+        "introduced": "2008-03-18"
+      },
+      {
+        "name": "-webkit-mask-composite",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-mask-composite",
+        "specUrl": null,
+        "introduced": "2008-03-18"
+      },
+      {
+        "name": "-webkit-mask-position-x",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-mask-position-x",
+        "specUrl": null,
+        "introduced": "2008-03-18"
+      },
+      {
+        "name": "-webkit-mask-position-y",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-mask-position-y",
+        "specUrl": null,
+        "introduced": "2008-03-18"
+      },
+      {
+        "name": "-webkit-mask-repeat-x",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-mask-repeat-x",
+        "specUrl": null,
+        "introduced": "2009-09-15"
+      },
+      {
+        "name": "-webkit-mask-repeat-y",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-mask-repeat-y",
+        "specUrl": null,
+        "introduced": "2009-09-15"
+      },
+      {
+        "name": "-webkit-mask-source-type",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2013-09-18"
+      },
+      {
+        "name": "-webkit-max-logical-height",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2010-12-02"
+      },
+      {
+        "name": "-webkit-max-logical-width",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2010-12-02"
+      },
+      {
+        "name": "-webkit-min-logical-height",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2010-12-02"
+      },
+      {
+        "name": "-webkit-min-logical-width",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2010-12-02"
+      },
+      {
+        "name": "-webkit-nbsp-mode",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-perspective-origin-x",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2009-05-21"
+      },
+      {
+        "name": "-webkit-perspective-origin-y",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2009-05-21"
+      },
+      {
+        "name": "-webkit-rtl-ordering",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-tap-highlight-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-tap-highlight-color",
+        "specUrl": null,
+        "introduced": "2010-06-21"
+      },
+      {
+        "name": "-webkit-text-combine",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2011-02-03"
+      },
+      {
+        "name": "-webkit-text-decorations-in-effect",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-text-fill-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-text-fill-color",
+        "specUrl": "https://compat.spec.whatwg.org/#the-webkit-text-fill-color",
+        "introduced": "2007-10-26"
+      },
+      {
+        "name": "-webkit-text-security",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-text-security",
+        "specUrl": null,
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "-webkit-text-stroke",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-text-stroke",
+        "specUrl": "https://compat.spec.whatwg.org/#the-webkit-text-stroke",
+        "introduced": "2007-10-26"
+      },
+      {
+        "name": "-webkit-text-stroke-color",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-text-stroke-color",
+        "specUrl": "https://compat.spec.whatwg.org/#the-webkit-text-stroke-color",
+        "introduced": "2007-10-26"
+      },
+      {
+        "name": "-webkit-text-stroke-width",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-text-stroke-width",
+        "specUrl": "https://compat.spec.whatwg.org/#the-webkit-text-stroke-width",
+        "introduced": "2007-10-26"
+      },
+      {
+        "name": "-webkit-text-zoom",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2016-09-13"
+      },
+      {
+        "name": "-webkit-touch-callout",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/-webkit-touch-callout",
+        "specUrl": null,
+        "introduced": "2008-07-11"
+      },
+      {
+        "name": "-webkit-transform-origin-x",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-transform-origin-y",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "-webkit-transform-origin-z",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2009-05-21"
+      },
+      {
+        "name": "-webkit-user-drag",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2008-12-11"
+      },
+      {
+        "name": "alt",
+        "mdnUrl": null,
+        "specUrl": null,
+        "introduced": "2015-09-16"
+      },
+      {
+        "name": "animation-range",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-range",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#animation-range",
+        "introduced": "2023-07-18"
+      },
+      {
+        "name": "animation-range-end",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-range-end",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#animation-range-end",
+        "introduced": "2023-07-18"
+      },
+      {
+        "name": "animation-range-start",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-range-start",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#animation-range-start",
+        "introduced": "2023-07-18"
+      },
+      {
+        "name": "border-collapse",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-collapse",
+        "specUrl": "https://drafts.csswg.org/css2/#propdef-border-collapse",
+        "introduced": "1999-03-18"
+      },
+      {
+        "name": "border-spacing",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/border-spacing",
+        "specUrl": "https://drafts.csswg.org/css2/#separated-borders",
+        "introduced": "2000-06-28"
+      },
+      {
+        "name": "box-align",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-align",
+        "specUrl": null,
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "box-direction",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-direction",
+        "specUrl": null,
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "box-flex",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-flex",
+        "specUrl": null,
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "box-flex-group",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-flex-group",
+        "specUrl": null,
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "box-lines",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-lines",
+        "specUrl": null,
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "box-ordinal-group",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-ordinal-group",
+        "specUrl": null,
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "box-orient",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-orient",
+        "specUrl": null,
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "box-pack",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/box-pack",
+        "specUrl": null,
+        "introduced": "2007-06-29"
+      },
+      {
+        "name": "caption-side",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/caption-side",
+        "specUrl": [
+          "https://drafts.csswg.org/css2/#propdef-caption-side",
+          "https://drafts.csswg.org/css-logical/#caption-side"
+        ],
+        "introduced": "2000-06-28"
+      },
+      {
+        "name": "clear",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/clear",
+        "specUrl": [
+          "https://drafts.csswg.org/css2/#propdef-clear",
+          "https://drafts.csswg.org/css-logical/#float-clear"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "empty-cells",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/empty-cells",
+        "specUrl": "https://drafts.csswg.org/css2/#empty-cells",
+        "introduced": "2000-06-28"
+      },
+      {
+        "name": "float",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/float",
+        "specUrl": [
+          "https://drafts.csswg.org/css2/#propdef-float",
+          "https://drafts.csswg.org/css-logical/#float-clear"
+        ],
+        "introduced": "1997-09-30"
+      },
+      {
+        "name": "font-smooth",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-smooth",
+        "specUrl": null,
+        "introduced": "2009-06-08"
+      },
+      {
+        "name": "math-depth",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/math-depth",
+        "specUrl": "https://w3c.github.io/mathml-core/#the-math-script-level-property",
+        "introduced": "2023-01-10"
+      },
+      {
+        "name": "math-shift",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/math-shift",
+        "specUrl": "https://w3c.github.io/mathml-core/#the-math-shift",
+        "introduced": "2023-01-10"
+      },
+      {
+        "name": "math-style",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/math-style",
+        "specUrl": "https://w3c.github.io/mathml-core/#the-math-style-property",
+        "introduced": "2021-04-26"
+      },
+      {
+        "name": "scroll-timeline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-timeline",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#scroll-timeline-shorthand",
+        "introduced": "2023-03-14"
+      },
+      {
+        "name": "scroll-timeline-axis",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-timeline-axis",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#propdef-scroll-timeline-axis",
+        "introduced": "2023-03-14"
+      },
+      {
+        "name": "scroll-timeline-name",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-timeline-name",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#scroll-timeline-name",
+        "introduced": "2023-03-14"
+      },
+      {
+        "name": "table-layout",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/table-layout",
+        "specUrl": "https://drafts.csswg.org/css2/#width-layout",
+        "introduced": "1999-03-18"
+      },
+      {
+        "name": "timeline-scope",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-scope",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#propdef-timeline-scope",
+        "introduced": "2023-08-15"
+      },
+      {
+        "name": "user-modify",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/user-modify",
+        "specUrl": null,
+        "introduced": "2004-11-09"
+      },
+      {
+        "name": "view-timeline",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/view-timeline",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#view-timeline-shorthand",
+        "introduced": "2023-06-06"
+      },
+      {
+        "name": "view-timeline-axis",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/view-timeline-axis",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#view-timeline-axis",
+        "introduced": "2023-06-06"
+      },
+      {
+        "name": "view-timeline-inset",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/view-timeline-inset",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#view-timeline-inset",
+        "introduced": "2023-07-18"
+      },
+      {
+        "name": "view-timeline-name",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/view-timeline-name",
+        "specUrl": "https://drafts.csswg.org/scroll-animations/#view-timeline-name",
+        "introduced": "2023-03-14"
+      },
+      {
+        "name": "z-index",
+        "mdnUrl": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/z-index",
+        "specUrl": "https://drafts.csswg.org/css2/#z-index",
+        "introduced": "1997-09-30"
+      }
+    ]
+  }
+];

--- a/src/pages/topics.astro
+++ b/src/pages/topics.astro
@@ -1,0 +1,139 @@
+---
+import Base from '../layouts/Base.astro';
+import Github from '../components/Github.astro';
+import ScrollToTop from '../components/ScrollToTop.astro';
+import { topics } from '../data/topics.js';
+---
+
+<Base>
+  <main class="main">
+    <header class="intro">
+      <h1>CSS-свойства по темам</h1>
+      <p>
+        Полный перечень свойств из архива проекта, распределённый по основным направлениям CSS.
+        Для удобства навигации используйте список тем и раскрывайте интересующие категории.
+      </p>
+    </header>
+
+    <section class="topics">
+      {topics.map((group) => (
+        <article class="topic" id={group.theme.toLowerCase().replace(/[^a-z0-9]+/g, '-')}> 
+          <details open>
+            <summary>{group.theme}</summary>
+            <ul>
+              {group.items.map((item) => (
+                <li>
+                  {item.mdnUrl ? (
+                    <a href={item.mdnUrl} target="_blank" rel="noopener noreferrer">
+                      {item.name}
+                    </a>
+                  ) : (
+                    <span>{item.name}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </details>
+        </article>
+      ))}
+    </section>
+  </main>
+  <Github />
+  <ScrollToTop />
+</Base>
+
+<style>
+  .main {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem 1rem 4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .intro h1 {
+    font-size: clamp(2rem, 3vw, 3rem);
+    margin-bottom: 1rem;
+  }
+
+  .intro p {
+    color: var(--color-text-muted, #4b5563);
+    line-height: 1.6;
+    max-width: 70ch;
+  }
+
+  .topics {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .topic details {
+    background: var(--color-surface, #fff);
+    border: 1px solid var(--color-border, rgb(148 163 184 / 30%));
+    border-radius: 12px;
+    box-shadow: 0 10px 30px rgb(15 23 42 / 8%);
+    padding: 1rem 1.25rem;
+    transition: box-shadow 0.2s ease;
+  }
+
+  .topic details[open] {
+    box-shadow: 0 18px 40px rgb(15 23 42 / 12%);
+  }
+
+  .topic summary {
+    font-weight: 600;
+    cursor: pointer;
+    font-size: 1.125rem;
+    list-style: none;
+  }
+
+  .topic summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .topic ul {
+    margin: 1rem 0 0;
+    padding: 0;
+    list-style: none;
+    columns: 1;
+    gap: 0.75rem;
+  }
+
+  .topic li {
+    margin-bottom: 0.4rem;
+  }
+
+  .topic a {
+    color: var(--color-accent, #2563eb);
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .topic a:hover,
+  .topic a:focus {
+    color: var(--color-accent-strong, #1d4ed8);
+    text-decoration: underline;
+  }
+
+  @media (width >= 768px) {
+    .topics {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .topic ul {
+      columns: 2;
+    }
+  }
+
+  @media (width >= 1200px) {
+    .topics {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .topic ul {
+      columns: 3;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- generate a derived dataset that groups every CSS property from the archive into themed topics
- add a new Astro page that renders the grouped topics with collapsible sections and links to MDN

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_6907b0c56c088321a84bd97e58b5f149